### PR TITLE
Added the cleanuporig alias

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,6 +1,9 @@
 # dotfiles
 alias dotfiles='cd $DOTFILES_LOCATION'
 
+# general
+alias cleanuporig='git clean -f *.orig && git clean -f **/*.orig'
+
 # command shortcuts
 alias lsl='ls -l'
 alias lsa='ls -la'


### PR DESCRIPTION
This is a quick PR that adds a new alias `cleanuporig`.

This new alias will remove all `*.orig` files, usually resulting from a `git merge` or `git rebase` with conflicts.